### PR TITLE
fix platform dependent directive for IOS builds

### DIFF
--- a/Editor/BuildPostProcessor.cs
+++ b/Editor/BuildPostProcessor.cs
@@ -16,7 +16,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
-#if UNITY_EDITOR
+#if (UNITY_EDITOR && UNITY_IOS)
 
 namespace Google.XR.Cardboard.Editor
 {


### PR DESCRIPTION
"UnityEditor.iOS.Xcode" is present only when Unity IOS Module installed as build module in Editor. 
For this cases I put additional UNITY_IOS directive to be executable only when we switch build target to IOS.
Otherwise, in my case with Windows Editor with only Android and Windows Standalone build target installed whole plugin crash because there no "UnityEditor.iOS.Xcode" present.
Tested in Unity 2019.4.3f1.