### PR TITLE
Set descriptive names for Display and Input XR Subsystems

### DIFF
--- a/Runtime/XRLoader.cs
+++ b/Runtime/XRLoader.cs
@@ -82,9 +82,9 @@ namespace Google.XR.Cardboard
         {
             CardboardSDKInitialize();
             CreateSubsystem<XRDisplaySubsystemDescriptor, XRDisplaySubsystem>(
-                _displaySubsystemDescriptors, "Display");
+                _displaySubsystemDescriptors, "cardboard display");
             CreateSubsystem<XRInputSubsystemDescriptor, XRInputSubsystem>(
-                _inputSubsystemDescriptors, "Input");
+                _inputSubsystemDescriptors, "cardboard input");
             _isInitialized = true;
             return true;
         }


### PR DESCRIPTION
This PR proposes a patch for https://github.com/googlevr/cardboard/issues/282

To determine what Display XR subsystem is active on runtime, one can query`UnityEngine.XR.XRSettings.loadedDeviceName`. Currently, this is set to the ambiguous value `Display`, see: 
https://github.com/googlevr/cardboard-xr-plugin/blob/48e5eafae7d60bf65b5be9435a70b7234a474062/Runtime/XRLoader.cs#L85

The same issue applies to the Input XR subsystem. 

In this PR we change the value to `cardboard display` and `cardboard input`. These names are chosen to be in line with other popular XR SDKs like Oculus, Pico VR and Skyworth VR. Note that the capitalization differs between XR SDKs. We chose an all lowercase name similar to Oculus XR.
