### PR TITLE
Added missing meta files.

### DIFF
--- a/Runtime/Android/THIRD_PARTY_NOTICES.txt.meta
+++ b/Runtime/Android/THIRD_PARTY_NOTICES.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f1d64c8890dc4b41aa144b4bd27dc32
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/iOS/THIRD_PARTY_NOTICES.txt.meta
+++ b/Runtime/iOS/THIRD_PARTY_NOTICES.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 21f602b15dec74dec87b11914a17c617
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Two new files were recently added to this repo without their `.meta` counterparts. This PR adds those missing files.

- [Runtime/Android/THIRD_PARTY_NOTICES.txt](https://github.com/googlevr/cardboard-xr-plugin/blob/master/Runtime/Android/THIRD_PARTY_NOTICES.txt)
- [Runtime/iOS/THIRD_PARTY_NOTICES.txt](https://github.com/googlevr/cardboard-xr-plugin/blob/master/Runtime/iOS/THIRD_PARTY_NOTICES.txt)

Without the `.meta` files, after installing the latest package, you will get the following errors:

```
Asset Packages/com.google.xr.cardboard/Runtime/Android/THIRD_PARTY_NOTICES.txt has no meta file, but it's in an immutable folder. The asset will be ignored.
Asset Packages/com.google.xr.cardboard/Runtime/iOS/THIRD_PARTY_NOTICES.txt has no meta file, but it's in an immutable folder. The asset will be ignored.
```

I tried submitting a Contributor License Agreement, but submitting the form resulted in a 400 error.