### PR TITLE
Adding resolutions.csv file manually

### DIFF
--- a/Runtime/iOS/sdk.bundle/resolutions.csv
+++ b/Runtime/iOS/sdk.bundle/resolutions.csv
@@ -1,0 +1,62 @@
+identifier,device_name,dpis
+iPhone1.1,iPhone,326.0f
+iPhone1.2,iPhone 3G,326.0f
+iPhone2.1,iPhone 3Gs,326.0f
+iPhone3.1,iPhone 4,326.0f
+iPhone3.2,iPhone 4,326.0f
+iPhone3.3,iPhone 4,326.0f
+iPhone4.1,iPhone 4s,326.0f
+iPhone4.2,iPhone 4s,326.0f
+iPhone5.1,iPhone 5,326.0f
+iPhone5.2,iPhone 5,326.0f
+iPhone5.3,iPhone 5c,326.0f
+iPhone5.4,iPhone 5c,326.0f
+iPhone6.1,iPhone 5s,326.0f
+iPhone6.2,iPhone 5s,326.0f
+iPhone7.1,iPhone 6 Plus,401.0f
+iPhone7.2,iPhone 6,326.0f
+iPhone8.1,iPhone 6s,326.0f
+iPhone8.2,iPhone 6s Plus,401.0f
+iPhone8.4,iPhone SE,326.0f
+iPhone9.1,iPhone 7,326.0f
+iPhone9.2,iPhone 7 Plus,401.0f
+iPhone9.3,iPhone 7,326.0f
+iPhone9.4,iPhone 7 Plus,401.0f
+iPhone10.1,iPhone 8,326.0f
+iPhone10.2,iPhone 8 Plus,401.0f
+iPhone10.3,iPhone X,458.0f
+iPhone10.4,iPhone 8,326.0f
+iPhone10.5,iPhone 8 Plus,401.0f
+iPhone10.6,iPhone X,458.0f
+iPhone11.2,iPhone Xs,458.0f
+iPhone11.4,iPhone Xs Max,456.0f
+iPhone11.6,iPhone Xs Max,456.0f
+iPhone11.8,iPhone Xr,456.0f
+iPhone12.1,iPhone 11,326.0f
+iPhone12.3,iPhone 11 Pro,458.0f
+iPhone12.5,iPhone 11 Pro Max,458.0f
+iPhone13.1,iPhone 12 Mini,476.0f
+iPhone13.2,iPhone 12,460.0f
+iPhone13.3,iPhone 12 Pro,460.0f
+iPhone13.4,iPhone 12 Pro Max,458.0f
+iPhone14.4,iPhone 13 Mini,476.0f
+iPhone14.5,iPhone 13,460.0f
+iPhone14.2,iPhone 13 Pro,460.0f
+iPhone14.3,iPhone 13 Pro Max,458.0f
+iPhone14.7,iPhone 14,460.0f
+iPhone14.8,iPhone 14 Plus,458.0f
+iPhone15.2,iPhone 14 Pro,460.0f
+iPhone15.3,iPhone 14 Pro Max,460.0f
+iPhone15.4,iPhone 15,460.0f
+iPhone15.5,iPhone 15 Plus,460.0f
+iPhone16.1,iPhone 15 Pro,460.0f
+iPhone16.2,iPhone 15 Pro Max,460.0f
+iPhone17.3,iPhone 16,460.0f
+iPhone17.4,iPhone 16 Plus,460.0f
+iPhone17.1,iPhone 16 Pro,460.0f
+iPhone17.2,iPhone 16 Pro Max,460.0f
+iPhone18.4,iPhone Air,460.0f
+iPhone18.3,iPhone 17,460.0f
+iPhone18.1,iPhone 17 Pro,460.0f
+iPhone18.2,iPhone 17 Pro Max,460.0f
+iPod9.1,iPod touch (7th generation),326.0f


### PR DESCRIPTION
Adding resolutions file to make ios screen params work properly. This fixes the crash that appears when the file is not found. 